### PR TITLE
data loss prevention: confirmation on page reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,15 @@
   </head>
 
   <body>
+    <script>
+      window.onbeforeunload = function (event) {
+        const message = "Are you sure you want to leave this page?";
+
+        event.returnValue = message;
+        return message;
+      };
+    </script>
+
     <form id="scoutingForm" onsubmit="return false" name="scoutingForm">
       <div id="main-panel-holder">
         <div id="prematch" class="main-panel" style="background-color: black">


### PR DESCRIPTION
This is to prevent data loss upon reload of the page.
It will _only trigger_ if the user has interacted with the match scouting form.